### PR TITLE
Support for Intel compilers

### DIFF
--- a/src/inition/gdr_int.f
+++ b/src/inition/gdr_int.f
@@ -163,7 +163,7 @@
       double precision tpint
       integer i,itot
 !if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
-      double precision besj1
+      double precision dbesj1
 !endif
       include 'ion.f'
       include 'gdr.f'
@@ -208,7 +208,7 @@
          f1=1d0/(1d0+qsq/q0)**2
          
          wt=tpint(1,dsqrt(qsq))*qt
-         wt=wt*besj1(bt*qt)*f1
+         wt=wt*dbesj1(bt*qt)*f1
 
          wt=wt*hlq2
 

--- a/src/inition/gdr_int.f
+++ b/src/inition/gdr_int.f
@@ -162,7 +162,9 @@
       double precision qtmin,hlq2
       double precision tpint
       integer i,itot
-
+!if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+      double precision besj1
+!endif
       include 'ion.f'
       include 'gdr.f'
       include 'mion.f'

--- a/src/inition/screen.f
+++ b/src/inition/screen.f
@@ -5,7 +5,7 @@
       double precision b0,hbt0,sum0,btminb
       integer iphi,ibt,nphi,nbt,nbt1,nbt2,nbt0
 !if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
-      double precision besj0 
+      double precision dbesj0 
 !endif
       include 'pi.f'
       include 'ion.f'
@@ -46,7 +46,7 @@
          if(beam.eq.'ion')wt=1d0-opacpbint(bt)
          if(beam.eq.'ionp')wt=1d0-opacpbpint(bt)
 
-         wt=wt*besj0(qt*bt)
+         wt=wt*dbesj0(qt*bt)
          wt=-wt*bt*hbt0/2d0/pi
 
          sum0=sum0+wt
@@ -65,7 +65,7 @@
          if(beam.eq.'ion')wt=1d0-opacpbint(bt)
          if(beam.eq.'ionp')wt=1d0-opacpbpint(bt)
  
-         wt=wt*besj0(qt*bt)
+         wt=wt*dbesj0(qt*bt)
          wt=-wt*bt*hbt/2d0/pi
 
          sum=sum+wt

--- a/src/inition/screen.f
+++ b/src/inition/screen.f
@@ -4,7 +4,9 @@
       double precision opacpbpint,opacpbint
       double precision b0,hbt0,sum0,btminb
       integer iphi,ibt,nphi,nbt,nbt1,nbt2,nbt0
-
+!if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+      double precision besj0 
+!endif
       include 'pi.f'
       include 'ion.f'
       include 'beam.f'

--- a/src/inition/screen_01.f
+++ b/src/inition/screen_01.f
@@ -5,7 +5,9 @@
       double precision b0,hbt0,sum0,btminb
       double precision btmin,btmax,aj0,aj0t,opac0,sumt
       integer iphi,ibt,nphi,nbt,nbt1,nbt2,nbt0
-
+!if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+      double precision besj0 
+!endif
       include 'pi.f'
       include 'ion.f'
       include 'beam.f'

--- a/src/inition/screen_01.f
+++ b/src/inition/screen_01.f
@@ -43,7 +43,7 @@ cccccccccccc
          opac0=opac0/(-2d0*pi*aj0)*bt
 
          wt=wt*(opac0-1d0)
-         wt=wt*besj0(qt*bt)
+         wt=wt*dbesj0(qt*bt)
          wt=wt*hbt
 
          sumt=sumt+wt

--- a/src/inition/screen_01.f
+++ b/src/inition/screen_01.f
@@ -6,7 +6,7 @@
       double precision btmin,btmax,aj0,aj0t,opac0,sumt
       integer iphi,ibt,nphi,nbt,nbt1,nbt2,nbt0
 !if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
-      double precision besj0 
+      double precision dbesj0 
 !endif
       include 'pi.f'
       include 'ion.f'

--- a/src/inition/sudgam.f
+++ b/src/inition/sudgam.f
@@ -33,7 +33,7 @@
       double precision sudgam_bt
       integer n,ntot
 !if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
-      double precision besj0 
+      double precision dbesj0 
 !endif
       include 'pi.f'
       include 'ion.f'
@@ -46,7 +46,7 @@
       ntot=1000
       hb=btmax/dble(ntot)
 
-c      write(6,*)besj0(0d0)
+c      write(6,*)dbesj0(0d0)
 c      stop
       
       do n=1,ntot
@@ -54,11 +54,11 @@ c      stop
          bt=(dble(n)-0.5d0)*hb
 
          wt=sudgam_bt(bt,mll)
-         wt=wt*bt*besj0(bt*lt)
+         wt=wt*bt*dbesj0(bt*lt)
          wt=wt/(2d0*pi)*hb
 
 c         write(6,*)'bt',bt,sudgam_bt(bt,mll)
-c         write(6,*)bt*besj0(bt*lt),bt*besj0(bt*lt)*hb
+c         write(6,*)bt*dbesj0(bt*lt),bt*dbesj0(bt*lt)*hb
 
          sum=sum+wt
          

--- a/src/inition/sudgam.f
+++ b/src/inition/sudgam.f
@@ -32,7 +32,9 @@
       double precision btmax,hb,sum,wt,sudgam,bt,lt,mll
       double precision sudgam_bt
       integer n,ntot
-
+!if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+      double precision besj0 
+!endif
       include 'pi.f'
       include 'ion.f'
       

--- a/src/inition/tp.f
+++ b/src/inition/tp.f
@@ -3,7 +3,7 @@
       double precision sum,btmax,hb,qt,tpz,bt,wt,rhoxyint
       integer n,ntot
 !if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
-      double precision besj0 
+      double precision dbesj0 
 !endif
       include 'pi.f'
       include 'ion.f'
@@ -20,7 +20,7 @@
          bt=(dble(n)-0.5d0)*hb
 
          wt=rhoxyint(1,bt)
-         wt=wt*bt*besj0(bt*qt)
+         wt=wt*bt*dbesj0(bt*qt)
          wt=wt*2d0*pi*hb
 
          sum=sum+wt
@@ -37,7 +37,7 @@
       double precision btmax,sum,hb,bt,qt,wt,rhoxyint,tpn
       integer n,ntot
 !if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
-      double precision besj0 
+      double precision dbesj0 
 !endif
       include 'pi.f'
       include 'ion.f'
@@ -55,7 +55,7 @@
          bt=(dble(n)-0.5d0)*hb
 
          wt=rhoxyint(2,bt)
-         wt=wt*bt*besj0(bt*qt)
+         wt=wt*bt*dbesj0(bt*qt)
          wt=wt*2d0*pi*hb
 
          sum=sum+wt

--- a/src/inition/tp.f
+++ b/src/inition/tp.f
@@ -2,7 +2,9 @@
       implicit none
       double precision sum,btmax,hb,qt,tpz,bt,wt,rhoxyint
       integer n,ntot
-
+!if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+      double precision besj0 
+!endif
       include 'pi.f'
       include 'ion.f'
       
@@ -34,7 +36,9 @@
       implicit none
       double precision btmax,sum,hb,bt,qt,wt,rhoxyint,tpn
       integer n,ntot
-
+!if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+      double precision besj0 
+!endif
       include 'pi.f'
       include 'ion.f'
   


### PR DESCRIPTION
Support for Intel compilers.
The `besj0` and `besj1` are listed as `Portability Functions` in https://www.intel.com/content/www/us/en/docs/fortran-compiler/developer-guide-reference/2023-1/a-to-b.html as real functions only, one should use the double versions explicitly.