### PR TITLE
More fixes to prevent FPEs

### DIFF
--- a/src/phase/chidecay.f
+++ b/src/phase/chidecay.f
@@ -12,8 +12,8 @@ ccc   generates rho meson invariant mass distribution according to modified BW
       mminr=mres-10d0*width
       mmaxr=mres+10d0*width
 
-      almin=datan(-(mres**2-mminr**2)/width/mres)
-      almax=datan(-(mres**2-mmaxr**2)/width/mres)
+      almin=datan2(-(mres**2-mminr**2),width*mres)
+      almax=datan2(-(mres**2-mmaxr**2),width*mres)
 
       norm=almax-almin
 

--- a/src/subamps/djpsip.f
+++ b/src/subamps/djpsip.f
@@ -36,10 +36,10 @@ cccccccc
       beta=dsqrt(1d0-4d0*mq**2/mx**2)
       cost=p1(3)/dsqrt(p1(1)**2+p1(2)**2+p1(3)**2)
 
-      phi=datan(p1(2)/p1(1))
+      phi=datan2(p1(2),p1(1))
+      cphi=dcos(phi)
+      sphi=dsin(phi)
 
-      cphi=p1(1)/dsqrt(p1(1)**2+p1(2)**2)
-      sphi=p1(2)/dsqrt(p1(1)**2+p1(2)**2)
 
       sintp=dsqrt(p1(1)**2+p1(2)**2)/p1(4)
      &*dsqrt(mx**2/8d0)

--- a/src/subamps/eta.f
+++ b/src/subamps/eta.f
@@ -3,7 +3,7 @@ ccc   gg --> eta(')eta(') subprocess amplitudes
       implicit none
       double precision qqn1,mx,pmqqns,pmqqs,ppgg,ppqg,ppqqs
       double precision ppn,mmn,pmn,mpn
-      double precision out1,out2,out3,norm,cost,beta
+      double precision out1,out2,out3,norm,cost
       double precision ggn1,a2gn,a28n,a21n
       double precision alphas,u,t
       integer p
@@ -13,8 +13,10 @@ ccc   gg --> eta(')eta(') subprocess amplitudes
       include 'mixing.f'
       include 'partonmom2.f'
 
-      beta=dsqrt(p1(1)**2+p1(2)**2+p1(3)**2)/p1(4)
-      cost=p1(3)/p1(4)/beta
+C      beta=dsqrt(p1(1)**2+p1(2)**2+p1(3)**2)/p1(4)
+C      cost=p1(3)/p1(4)/beta
+      cost=p1(3)/dsqrt(p1(1)**2+p1(2)**2+p1(3)**2)
+       
 
       ppn=(1d0+cost**2)/(1d0-cost**2)**2
       mmn=ppn

--- a/src/subamps/etaetap.f
+++ b/src/subamps/etaetap.f
@@ -13,9 +13,10 @@ ccc   gg --> etaeta' subprocess amplitude
 
 cccccc
 
-      phi=datan(p1(2)/p1(1))
-      cphi=p1(1)/dsqrt(p1(1)**2+p1(2)**2)
-      sphi=p1(2)/dsqrt(p1(1)**2+p1(2)**2)
+      phi=datan2(p1(2),p1(1))
+      cphi=dcos(phi)
+      sphi=dsin(phi)
+
 
 cccccc
 

--- a/src/subamps/ggjets.f
+++ b/src/subamps/ggjets.f
@@ -2,15 +2,16 @@ ccc   gg --> gg subprocess amplitude
       subroutine gg(p,mx,u,t,pp,mm,pm,mp)
       implicit none
       complex*16 pp,mm,pm,mp
-      double precision sphi,cphi,u,t,mx,alphas
+      double precision sphi,cphi,u,t,mx,alphas,phi
       integer p
 
       include 'zi.f'
       include 'pi.f'
       include 'partonmom2.f'
 
-      cphi=p1(1)/dsqrt(p1(1)**2+p1(2)**2)
-      sphi=p1(2)/dsqrt(p1(1)**2+p1(2)**2)
+      phi=datan2(p1(2),p1(1))
+      cphi=dcos(phi)
+      sphi=dsin(phi)
 
       if(p.eq.1)then            ! ++ final state
          pp=3d0/dsqrt(8d0)*8d0*pi*alphas(mx**2)

--- a/src/subamps/mmpol.f
+++ b/src/subamps/mmpol.f
@@ -1,7 +1,7 @@
 ccc   gamma gamma --> MM subprocess amplitude
       subroutine mmpol(p,mx,u,t,pp,mm,pm,mp)
       implicit none
-      double precision sphi,cphi,sintt,costt
+      double precision sphi,cphi,sintt,costt,phi
       double precision normp,gam,beta,u,t,mx
       complex*16 pp,mm,pm,mp
       integer p
@@ -19,9 +19,10 @@ ccc   gamma gamma --> MM subprocess amplitude
       gam=mx**2/mq**2
       costt=(t-u)/beta/mx**2
       sintt=dsqrt(1d0-costt**2)
-
-      cphi=p1(1)/dsqrt(p1(1)**2+p1(2)**2)
-      sphi=p1(2)/dsqrt(p1(1)**2+p1(2)**2)
+      
+      phi=datan2(p1(2),p1(1))
+      cphi=dcos(phi)
+      sphi=dsin(phi)
 
       if(p.eq.1)then !++
          pp=4d0*mq*(1d0+beta)/mx


### PR DESCRIPTION
More fixes to prevent FPEs.

Hi @LucianHL , that is basically it. All other cases of FPEs are either pure divisions by zero and one shoul make a cut , or expressions like
``dsqrt(1.0-x**2/m**2)`` where something is obviously wrong on the level of input, i.e. control cards, integration limits, etc.


Andrii