### PR TITLE
Avoid divisions in comparison

### DIFF
--- a/src/main/superchic.f
+++ b/src/main/superchic.f
@@ -821,7 +821,7 @@ c      write(40,*)7
 c      print*,'test'
 
 
- 777  if(dabs(sd/avgi).gt.prec)then
+ 777  if(dabs(sd).gt.dabs(avgi)*prec)then
 
 
 

--- a/src/unw/unweight.f
+++ b/src/unw/unweight.f
@@ -12,7 +12,7 @@ ccc   writes event information to array for unweighted generation
       include 'leshouches.f'
       include 'wmax.f'
 
-      if(wt/wmax.gt.r)then
+      if(wt.gt.r*wmax)then
 
          evnum=evnum+1
 


### PR DESCRIPTION
Avoid divisions in comparison.

This is just an improvement. No known crash is related to the changed lines.