### PR TITLE
Add tests to validate raw LHE files

### DIFF
--- a/src/unw/unwprint.f
+++ b/src/unw/unwprint.f
@@ -135,7 +135,7 @@ ccccccccccccccccccccccccccccccccccccccccccccccc
             endif
 
             if(i.eq.1)then
-               write(45,*)'<LesHouchesEvents version="1.0">'
+               write(45,'(A)')'<LesHouchesEvents version="1.0">'
                write(45,*)'<header>'
                call headerlhe
                write(45,*)'</header>'

--- a/src/unw/unwprint_q.f
+++ b/src/unw/unwprint_q.f
@@ -289,7 +289,7 @@ ccccccccccccccccccccccccccccccccccccccccccccccc
            endif
 
             if(i.eq.1)then
-               write(45,*)'<LesHouchesEvents version="1.0">'
+               write(45,'(A)')'<LesHouchesEvents version="1.0">'
                write(45,*)'<header>'
                call headerlhe
                write(45,*)'</header>'

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -70,8 +70,11 @@ macro(sctestlhe NN MM df pr)
   #add_test(NAME SHOWER_${NN}_${MM} COMMAND shower ${CMAKE_CURRENT_BINARY_DIR}/RUN_${NN}/evrecs/evrectest${MM}.dat ${CMAKE_CURRENT_BINARY_DIR}/RUN_${NN}/evrecs/showered${MM}.hepmc ${df} ${pr} real)
   add_test(NAME SHOWER_${NN}_${MM} COMMAND shower ${CMAKE_CURRENT_BINARY_DIR}/RUN_${NN}/evrecs/evrectest${MM}.dat ${CMAKE_CURRENT_BINARY_DIR}/RUN_${NN}/evrecs/showered${MM}.hepmc ${df} ${pr} dummy)
   set_tests_properties( SHOWER_${NN}_${MM} PROPERTIES TIMEOUT 500 ENVIRONMENT "${STANDARDENVIRONMENT}" DEPENDS "shower;SUPERCHIC_${NN}_${MM}")
-  add_test(NAME VALIDATE_${NN}_${MM} COMMAND validator ${CMAKE_CURRENT_BINARY_DIR}/RUN_${NN}/evrecs/showered${MM}.hepmc)
-  set_tests_properties( VALIDATE_${NN}_${MM} PROPERTIES TIMEOUT 500 DEPENDS "validator;SHOWER_${NN}_${MM}")
+  add_test(NAME VALIDATE_SHOWERED_HEPMC_${NN}_${MM} COMMAND validator ${CMAKE_CURRENT_BINARY_DIR}/RUN_${NN}/evrecs/showered${MM}.hepmc)
+  set_tests_properties( VALIDATE_SHOWERED_HEPMC_${NN}_${MM} PROPERTIES TIMEOUT 500 DEPENDS "validator;SHOWER_${NN}_${MM}")
+  add_test(NAME VALIDATE_LHEF_${NN}_${MM} COMMAND validator ${CMAKE_CURRENT_BINARY_DIR}/RUN_${NN}/evrecs/evrectest${MM}.dat)
+  set_tests_properties( VALIDATE_LHEF_${NN}_${MM} PROPERTIES TIMEOUT 500 DEPENDS "validator;SUPERCHIC_${NN}_${MM}")
+
 endmacro()
 
 


### PR DESCRIPTION
Add tests to validate raw LHE files:
- add new tests to the test suite
- fix the formatting of LHE output -- remove leading space in the first line of the output file.