### PR TITLE
ATLAS-like showering config

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,14 +21,17 @@ if (SUPERCHIC_DOWNLOAD_PDFS)
   file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/PDFS)
   file(DOWNLOAD https://superchic.hepforge.org/SF_MSHT20qed_nnlo.tar.gz ${CMAKE_CURRENT_BINARY_DIR}/PDFS/SF_MSHT20qed_nnlo.tar.gz)
   file(DOWNLOAD https://lhapdfsets.web.cern.ch/current/MSHT20qed_nnlo.tar.gz ${CMAKE_CURRENT_BINARY_DIR}/PDFS/MSHT20qed_nnlo.tar.gz)
+  file(DOWNLOAD https://lhapdfsets.web.cern.ch/current/cteq6l1.tar.gz ${CMAKE_CURRENT_BINARY_DIR}/PDFS/cteq6l1.tar.gz)
   add_custom_target( UNZIPPDFS ALL)
   add_custom_command(TARGET UNZIPPDFS PRE_BUILD 
          COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_BINARY_DIR}/PDFS/SF_MSHT20qed_nnlo
          COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_BINARY_DIR}/PDFS/MSHT20qed_nnlo
+         COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_BINARY_DIR}/PDFS/cteq6l1
          COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/PDFS/SF_MSHT20qed_nnlo.tar.gz
          COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/PDFS/MSHT20qed_nnlo.tar.gz
+         COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/PDFS/cteq6l1.tar.gz
          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/PDFS
-         DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/PDFS/SF_MSHT20qed_nnlo.tar.gz  ${CMAKE_CURRENT_BINARY_DIR}/PDFS/MSHT20qed_nnlo.tar.gz
+         DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/PDFS/SF_MSHT20qed_nnlo.tar.gz  ${CMAKE_CURRENT_BINARY_DIR}/PDFS/MSHT20qed_nnlo.tar.gz ${CMAKE_CURRENT_BINARY_DIR}/PDFS/cteq6l1.tar.gz
          COMMENT "Unpacking PDFs"
          VERBATIM)
   LIST(APPEND STANDARDENVIRONMENT "LHAPDF_DATA_PATH=${CMAKE_CURRENT_BINARY_DIR}/PDFS")
@@ -67,8 +70,8 @@ macro(sctestlhe NN MM df pr)
   else()
     set_tests_properties( SUPERCHIC_${NN}_${MM} PROPERTIES TIMEOUT 500 ENVIRONMENT "${STANDARDENVIRONMENT}" DEPENDS "INIT_${NN}")  
   endif()
-  #add_test(NAME SHOWER_${NN}_${MM} COMMAND shower ${CMAKE_CURRENT_BINARY_DIR}/RUN_${NN}/evrecs/evrectest${MM}.dat ${CMAKE_CURRENT_BINARY_DIR}/RUN_${NN}/evrecs/showered${MM}.hepmc ${df} ${pr} real)
-  add_test(NAME SHOWER_${NN}_${MM} COMMAND shower ${CMAKE_CURRENT_BINARY_DIR}/RUN_${NN}/evrecs/evrectest${MM}.dat ${CMAKE_CURRENT_BINARY_DIR}/RUN_${NN}/evrecs/showered${MM}.hepmc ${df} ${pr} dummy)
+  add_test(NAME SHOWER_${NN}_${MM} COMMAND shower ${CMAKE_CURRENT_BINARY_DIR}/RUN_${NN}/evrecs/evrectest${MM}.dat ${CMAKE_CURRENT_BINARY_DIR}/RUN_${NN}/evrecs/showered${MM}.hepmc ${df} ${pr} real)
+  #add_test(NAME SHOWER_${NN}_${MM} COMMAND shower ${CMAKE_CURRENT_BINARY_DIR}/RUN_${NN}/evrecs/evrectest${MM}.dat ${CMAKE_CURRENT_BINARY_DIR}/RUN_${NN}/evrecs/showered${MM}.hepmc ${df} ${pr} dummy)
   set_tests_properties( SHOWER_${NN}_${MM} PROPERTIES TIMEOUT 500 ENVIRONMENT "${STANDARDENVIRONMENT}" DEPENDS "shower;SUPERCHIC_${NN}_${MM}")
   add_test(NAME VALIDATE_SHOWERED_HEPMC_${NN}_${MM} COMMAND validator ${CMAKE_CURRENT_BINARY_DIR}/RUN_${NN}/evrecs/showered${MM}.hepmc)
   set_tests_properties( VALIDATE_SHOWERED_HEPMC_${NN}_${MM} PROPERTIES TIMEOUT 500 DEPENDS "validator;SHOWER_${NN}_${MM}")

--- a/test/shower.cxx
+++ b/test/shower.cxx
@@ -19,12 +19,110 @@
 #endif
 #include "Pythia8/Pythia.h"
 using namespace Pythia8;
+
+std::vector<std::string> split(const std::string& str) {
+    std::vector<std::string> tokens;
+    std::string::size_type lastPos = str.find_first_not_of("\n", 0);
+    std::string::size_type pos     = str.find_first_of("\n", lastPos);
+    while (std::string::npos != pos || std::string::npos != lastPos) {
+        tokens.push_back(str.substr(lastPos, pos - lastPos));
+        lastPos = str.find_first_not_of("\n", pos);
+        pos = str.find_first_of("\n", lastPos);
+    }
+    return tokens;
+}
+std::string config_common =
+R"""(Tune:pp = 5
+Tune:ee = 3
+TimeShower:pTminChgQ = 0.40000
+TimeShower:pTmin = 0.40000
+TimeShower:alphaSvalue = 0.13830
+StringZ:rFactC = 1.00000
+StringZ:rFactB = 0.67000
+BeamRemnants:halfScaleForKT =  1.00000
+BeamRemnants:primordialKThard = 2.00000
+BeamRemnants:primordialKTsoft = 0.50000
+ColourReconnection:range =  1.50000
+Diffraction:largeMassSuppress =  2.00000
+MultipartonInteractions:alphaSvalue = 0.13500
+MultipartonInteractions:ecmPow = 0.19000
+MultipartonInteractions:ecmRef = 1800.000
+MultipartonInteractions:expPow = 2.00000
+MultipartonInteractions:pT0Ref = 2.08500
+Next:numberShowEvent = 0
+PDF:pSet = LHAPDF6:cteq6l1
+SigmaProcess:alphaSvalue = 0.13500
+SpaceShower:alphaSvalue = 0.13700
+SpaceShower:ecmRef = 1800.000
+StringFlav:etaSup = 0.63000
+StringFlav:mesonBvector = 3.00000
+StringFlav:mesonCvector = 1.06000
+StringFlav:mesonSvector = 0.72500
+StringFlav:mesonUDvector = 0.62000
+StringFlav:popcornSpair = 0.50000
+StringFlav:probQQ1toQQ0 = 0.0270000
+StringFlav:probQQtoQ = 0.0900000
+StringFlav:probSQtoQQ = 1.00000
+StringFlav:probStoUD = 0.19000
+StringPT:sigma = 0.30400
+StringZ:aExtraDiquark = 0.50000
+StringZ:aLund = 0.30000
+StringZ:bLund = 0.80000
+)""";
+std::string config_dd = R"""(
+PartonLevel:MPI = off
+SpaceShower:dipoleRecoil = on
+SpaceShower:pTmaxMatch = 2
+SpaceShower:QEDshowerByQ = on
+BeamRemnants:primordialKT = off
+BeamRemnants:unresolvedHadron = 0
+SpaceShower:pTdampMatch=1
+)""";
+
+std::string config_el = R"""(
+PartonLevel:MPI = off
+SpaceShower:pTmaxMatch = 2
+BeamRemnants:primordialKT = off
+BeamRemnants:unresolvedHadron = 3
+SpaceShower:pTdampMatch=1
+PartonLevel:ISR = off
+LesHouches:matchInOut = off
+)""";
+
+std::string config_ds = R"""(
+PartonLevel:MPI = off
+SpaceShower:dipoleRecoil = on
+SpaceShower:pTmaxMatch = 2
+BeamRemnants:primordialKT = off
+SpaceShower:QEDshowerByQ = off
+BeamRemnants:unresolvedHadron = 1
+SpaceShower:pTdampMatch = 1
+)""";
+
+std::string config_sd = R"""(
+PartonLevel:MPI = off
+SpaceShower:dipoleRecoil = on
+SpaceShower:pTmaxMatch = 2
+BeamRemnants:primordialKT = off
+SpaceShower:QEDshowerByQ = off
+BeamRemnants:unresolvedHadron = 2
+SpaceShower:pTdampMatch = 1
+)""";
+
+/*
 bool is_semi_exclusive_photon_initiated(int i) {
  return (( 48 <= i && i <=53 ) || ( 55 <= i && i <=83 ));
 
-}
+}*/
 int main(int argc, char ** argv) {
   if (argc!=6) return 1;
+  
+  std::vector<std::string> c_c = split(config_common);
+  std::vector<std::string> c_sd = split(config_sd);
+  std::vector<std::string> c_ds = split(config_ds);
+  std::vector<std::string> c_el = split(config_el);
+  std::vector<std::string> c_dd = split(config_dd);
+  
  Pythia8::Pythia8ToHepMC topHepMC(argv[2]);
   // Generator. We here stick with default values, but changes
   // could be inserted with readString or readFile.
@@ -34,28 +132,22 @@ int main(int argc, char ** argv) {
   pythia.readString("Beams:frameType = 4");
   pythia.readString(std::string("Beams:LHEF = ")+argv[1]);
   if ( std::string(argv[5]) != "dummy" ) {
-  pythia.readString("PartonLevel:ISR = off");
+   for ( auto s: c_c) pythia.readString(s);
+     pythia.readString("PartonLevel:ISR = off");
   pythia.readString("PartonLevel:MPI = off");
   pythia.readString("PartonLevel:Remnants = off");
   pythia.readString("Check:event = off");
   pythia.readString("LesHouches:matchInOut = off");
-  
+
   if (std::string(argv[3]) != "dd" && std::string(argv[3]) != "sda" && std::string(argv[3]) != "sdb" && std::string(argv[3]) != "el") { return 7;}
     printf("Running in %s mode\n",argv[3]);
   
   int processnumber = atoi(argv[4]);
-  if (is_semi_exclusive_photon_initiated(processnumber)) {
-    pythia.readString("BeamRemnants:primordialKT = off");
-    pythia.readString("PartonLevel:FSR = on");
-    pythia.readString("SpaceShower:dipoleRecoil = on");
-    pythia.readString("SpaceShower:pTmaxMatch = 2");
-    pythia.readString("SpaceShower:QEDshowerByQ = off");
-    pythia.readString("SpaceShower:pTdampMatch=1");
-    if (std::string(argv[3]) == "dd") pythia.readString("BeamRemnants:unresolvedHadron = 0");
-    if (std::string(argv[3]) == "sdb") pythia.readString("BeamRemnants:unresolvedHadron = 1");
-    if (std::string(argv[3]) == "sda") pythia.readString("BeamRemnants:unresolvedHadron = 2");
-    if (std::string(argv[3]) == "el") pythia.readString("BeamRemnants:unresolvedHadron = 3");
-  }
+    if (std::string(argv[3]) == "dd") for ( auto s: c_dd) pythia.readString(s);
+    if (std::string(argv[3]) == "sdb") for ( auto s: c_ds) pythia.readString(s);
+    if (std::string(argv[3]) == "sda") for ( auto s: c_sd) pythia.readString(s);
+    if (std::string(argv[3]) == "el") for ( auto s: c_el) pythia.readString(s);
+  
 }
   
 //BeamRemnants:unresolvedHadron = 0 for double dissociation (dd), 1 for


### PR DESCRIPTION
ATLAS-like showering config.

Hi @LucianHL,

the MR uses the control cards that are used for showering in ATLAS.
I'm sure that one can tune them further, but this is a good start.

Best regards,

Andrii

P.S. I'm very strict with equal treatment of  generators/experiments elsewhere for obvious reasons. But concerning the those control cards, I think that if there will be other groups interested in contributing to the code, one can add more control cards, but meanwhile we have * ATLAS* control cards and there are no reasons to pretend those are  not ATLAS control cards.

P.P.S. I would tag the interested people from ATLAS here, but I don't know their github accounts.


