### PR TITLE
Avoid using nint when ceiling can be used

### DIFF
--- a/src/sPDFs/hpdfint.f
+++ b/src/sPDFs/hpdfint.f
@@ -2,45 +2,38 @@ ccc   interpolator for skewed pdf
       subroutine hpdfint(x,qtsq,tg,dtg)
       implicit double precision(a-y)
       integer i,j
+      double precision iqinc, ilxinc
 
       include 'hgpars.f'
+      iqinc=1.0d0/qinc 
+      ilxinc=1.0d0/lxinc 
+       
+      i=max(1,ceiling((qtsq-qmin)*iqinc))
+      j=max(1,ceiling((x-lxmin)*ilxinc))
 
-      i=nint((qtsq-qmin)/qinc)
-      j=nint((x-lxmin)/lxinc)
-
-      if(dble(i).lt.(qtsq-qmin)/qinc)then
-         i=i+1
-      endif
-
-      if(dble(j).lt.(x-lxmin)/lxinc)then
-         j=j+1
-      endif
-
-      if(i.eq.0)i=i+1
-      if(j.eq.0)j=j+1
 
 cccccccccccc
 
-      m1=(hgint(3,i+1,j)-hgint(3,i,j))/qinc
+      m1=(hgint(3,i+1,j)-hgint(3,i,j))*iqinc
       tg1=hgint(3,i,j)+m1*(qtsq-hgint(1,i,j))
 
       tg1p=hgint(3,i+1,j)+m1*(qtsq-hgint(1,i+1,j))
 
-      m1=(hgint(4,i+1,j)-hgint(4,i,j))/qinc
+      m1=(hgint(4,i+1,j)-hgint(4,i,j))*iqinc
       dtg1=hgint(4,i,j)+m1*(qtsq-hgint(1,i,j))
 
-      m2=(hgint(3,i+1,j+1)-hgint(3,i,j+1))/qinc
+      m2=(hgint(3,i+1,j+1)-hgint(3,i,j+1))*iqinc
       tg2=hgint(3,i,j+1)+m2*(qtsq-hgint(1,i,j+1))
 
-      m2=(hgint(4,i+1,j+1)-hgint(4,i,j+1))/qinc
+      m2=(hgint(4,i+1,j+1)-hgint(4,i,j+1))*iqinc
       dtg2=hgint(4,i,j+1)+m2*(qtsq-hgint(1,i,j+1))
 
 ccccccccccccc
 
-      mf=(tg2-tg1)/lxinc
+      mf=(tg2-tg1)*ilxinc
       tg=tg1+mf*(x-hgint(2,i,j))
 
-      mf=(dtg2-dtg1)/lxinc
+      mf=(dtg2-dtg1)*ilxinc
       dtg=dtg1+mf*(x-hgint(2,i,j))
 
       return

--- a/src/sPDFs/sudint.f
+++ b/src/sPDFs/sudint.f
@@ -2,45 +2,37 @@ ccc   interpolator for Sudakov factor
       subroutine sudint(qtsq,mxx,tg,dtg)
       implicit double precision(a-y)
       integer i,j
+      double precision iqinc,iminc
 
       include 'sudpars.f'
 
       mx=dlog(mxx)
+      iqinc=1.0d0/qinc 
+      iminc=1.0d0/minc 
+      i=max(1,ceiling((qtsq-qmin)*iqinc))
+      j=max(1,ceiling((mx-mmin)*iminc))
 
-      i=nint((qtsq-qmin)/qinc)
-      j=nint((mx-mmin)/minc)
-
-      if(dble(i).lt.(qtsq-qmin)/qinc)then
-         i=i+1
-      endif
-
-      if(dble(j).lt.(mx-mmin)/minc)then
-         j=j+1
-      endif
-
-      if(i.eq.0)i=i+1
-      if(j.eq.0)j=j+1
 
 cccccccccccc
 
-      m1=(tgint(3,i+1,j)-tgint(3,i,j))/qinc
+      m1=(tgint(3,i+1,j)-tgint(3,i,j))*iqinc
       tg1=tgint(3,i,j)+m1*(qtsq-tgint(1,i,j))
 
-      m1=(tgint(4,i+1,j)-tgint(4,i,j))/qinc
+      m1=(tgint(4,i+1,j)-tgint(4,i,j))*iqinc
       dtg1=tgint(4,i,j)+m1*(qtsq-tgint(1,i,j))
 
-      m2=(tgint(3,i+1,j+1)-tgint(3,i,j+1))/qinc
+      m2=(tgint(3,i+1,j+1)-tgint(3,i,j+1))*iqinc
       tg2=tgint(3,i,j+1)+m2*(qtsq-tgint(1,i,j+1))
 
-      m2=(tgint(4,i+1,j+1)-tgint(4,i,j+1))/qinc
+      m2=(tgint(4,i+1,j+1)-tgint(4,i,j+1))*iqinc
       dtg2=tgint(4,i,j+1)+m2*(qtsq-tgint(1,i,j+1))
 
 ccccccccccccc
 
-      mf=(tg2-tg1)/minc
+      mf=(tg2-tg1)*iminc
       tg=tg1+mf*(mx-tgint(2,i,j))
 
-      mf=(dtg2-dtg1)/minc
+      mf=(dtg2-dtg1)*iminc
       dtg=dtg1+mf*(mx-tgint(2,i,j))
 
       return


### PR DESCRIPTION
Avoid using nint when ceiling can be used. This improves the performance by ~5%.