### PR TITLE
Update publish.yml to fix gmake builds in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,6 +56,7 @@ jobs:
       run : |
          export SUPERCHIC_DATA_PATH=$(pwd)/share/SuperChic
          mkdir -p obj lib
+         sed -i '20s/.*/FFLAGS+=-mcmodel=medium/' makefile.make
          gmake -f makefile.make
          gmake -f makefile.make init
          ls -lah 


### PR DESCRIPTION
Update publish.yml to fix gmake builds  in CI
It seems that for Linux one needs a special flag for the builds