### PR TITLE
Proper error message for alphas

### DIFF
--- a/src/PDFs/alphas.f
+++ b/src/PDFs/alphas.f
@@ -1,8 +1,17 @@
 ccc   strong coupling constant, for PDFINPUT = LHAPDF
       function alphas(qsq)
       implicit double precision (a-z)
+      include 'pdfinf.f'
 
+      if (qsq.lt.pdfq2min) then 
+      if ( pdfwarn.ge.0) then
+      write(*,*)'Error in alphas.f qsq=',qsq,' < ',pdfq2min,pdfwarn
+      pdfwarn=pdfwarn-1
+      endif
+      alphas=alphasPDF(pdfq2min)
+      else
       alphas=alphasPDF(dsqrt(qsq))
+      end if
 
       return
       end

--- a/src/PDFs/alphas.f
+++ b/src/PDFs/alphas.f
@@ -5,7 +5,8 @@ ccc   strong coupling constant, for PDFINPUT = LHAPDF
 
       if (qsq.lt.pdfq2min) then 
       if ( pdfwarn.ge.0) then
-      write(*,*)'Error in alphas.f qsq=',qsq,' < ',pdfq2min,pdfwarn
+      write(*,*)'Warning in alphas.f qsq = ',qsq,' < ',pdfq2min,pdfwarn
+      write(*,*)'alphas being frozen at qsq = ',pdfq2min
       pdfwarn=pdfwarn-1
       endif
       alphas=alphasPDF(pdfq2min)

--- a/src/PDFs/inpdf.f
+++ b/src/PDFs/inpdf.f
@@ -11,6 +11,7 @@ cccccccccccccccccccccccccccccccccccccccccccccccccccc
       call initpdfset
      &     ('PDFsets/'//PDFname)
       call initpdf(PDFmember)
-
+      call getq2min(PDFmember,pdfq2min)
+      pdfwarn=10
       return
       end

--- a/src/inc/pdfinf.f
+++ b/src/inc/pdfinf.f
@@ -1,4 +1,8 @@
       character*100 PDFname
       integer PDFmember
+      double precision pdfq2min
+      integer pdfwarn
       common/pdfint/PDFname
       common/pdfint1/PDFmember
+      common/pdfbounds/pdfq2min
+      common/pdfwarn/pdfwarn


### PR DESCRIPTION
Proper error message for alphas.
Issue an error message in case the alphas argument is lower than the q2min of PDF.
Only 10 messages are issued.
The alphas is effectively frozen at alphas(q2min).
Should be a temporary solution.

