### PR TITLE
Perform AA tests for el and photon-initiated only

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -251,32 +251,22 @@ set( proc${i} "")
 endforeach()
 
 if (SUPERCHIC_ENABLE_ALL_TESTS)
-foreach( i IN ITEMS 1 2 3 4 5 6 7 8 9  
-           10 11 12 13 14 15 16 17 18 19 
-           20 21 22 23 24 25 26 27 28 29
-           30 31 32 33 34 35 36 37 38 39
-           40 41 42 43 44 45 46 47      
-                       54 55 56 57 58 59
-           60 61                   68 69
-           70 71 72 73 74 75 76 77 78 79
-                 82 83 84 
+foreach( i IN ITEMS  
+           55 56 57 58 59
+           60 68 69
+           70 71 72 73 74 75 76
            )
     list(APPEND proc${i} "el")
 endforeach()           
-foreach( i IN ITEMS 54 55 56 57 58
-             68 )
-    list(APPEND proc${i} "sda")
-    list(APPEND proc${i} "dd")
-endforeach()  
 else()
-  set(proc68 "el;sda;dd")
+  set(proc68 "el")
 endif()
 
 
 
 set(process 100)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.DAT_LHC13AAunw ${CMAKE_CURRENT_BINARY_DIR}/input.DAT_LHC13AAunw) # for init
-inittest(LHC13AAunw)
+# configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.DAT_LHC13AAunw ${CMAKE_CURRENT_BINARY_DIR}/input.DAT_LHC13AAunw) # for init
+# inittest(LHC13AAunw)
 foreach( process RANGE 1 100)
   LIST(LENGTH proc${process} LISTCOUNT)
   if (${LISTCOUNT}  GREATER 0)


### PR DESCRIPTION
And remove ./init - not needed for AA