### PR TITLE
Stop using processes 54 and 61 in the tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -378,25 +378,17 @@ set( proc${i} "")
 endforeach()
 
 if (SUPERCHIC_ENABLE_ALL_TESTS)
-foreach( i IN ITEMS 1 2 3 4 5 6 7 8 9  
-           10 11 12 13 14 15 16 17 18 19 
-           20 21 22 23 24 25 26 27 28 29
-           30 31 32 33 34 35 36 37 38 39
-           40 41 42 43 44 45 46 47 48 49
-           50 51 52 53    55 56 57 58 59
-           60                      68 69
+foreach( i IN ITEMS 
+                                   48 49
+           50 51 52 53 54 55 56 57 58 59
+           60 61                   68 69
            70 71 72 73 74 75 76 77 78 79
                  82 83 84 
            )
     list(APPEND proc${i} "el")
 endforeach()           
-foreach( i IN ITEMS    55 56 57 58
-             68 )
-    list(APPEND proc${i} "sda")
-    list(APPEND proc${i} "dd")
-endforeach()  
 else()
-  set(proc68 "el;sda;dd")
+  set(proc68 "el")
 endif()
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -238,14 +238,14 @@ foreach( i IN ITEMS 1 2 3 4 5 6 7 8 9
            20 21 22 23 24 25 26 27 28 29
            30 31 32 33 34 35 36 37 38 39
            40 41 42 43 44 45 46 47 48 49
-           50 51 52 53 54 55 56 57 58 59
-           60 61                   68 69
+           50 51 52 53    55 56 57 58 59
+           60                      68 69
            70 71 72 73 74 75 76 77 78 79
                  82 83 84 
            )
     list(APPEND proc${i} "el")
 endforeach()           
-foreach( i IN ITEMS 54 55 56 57 58
+foreach( i IN ITEMS    55 56 57 58
              68 )
     list(APPEND proc${i} "sda")
     list(APPEND proc${i} "dd")
@@ -287,7 +287,7 @@ endforeach()
 if (SUPERCHIC_ENABLE_ALL_TESTS)
 foreach( i IN  ITEMS
                           55 56 57 58 59
-           60 61                   68 69
+           60                      68 69
            70 71 72 73 74 75 76 
                  82 83 84 
            )
@@ -383,14 +383,14 @@ foreach( i IN ITEMS 1 2 3 4 5 6 7 8 9
            20 21 22 23 24 25 26 27 28 29
            30 31 32 33 34 35 36 37 38 39
            40 41 42 43 44 45 46 47 48 49
-           50 51 52 53 54 55 56 57 58 59
-           60 61                   68 69
+           50 51 52 53    55 56 57 58 59
+           60                      68 69
            70 71 72 73 74 75 76 77 78 79
                  82 83 84 
            )
     list(APPEND proc${i} "el")
 endforeach()           
-foreach( i IN ITEMS 54 55 56 57 58
+foreach( i IN ITEMS    55 56 57 58
              68 )
     list(APPEND proc${i} "sda")
     list(APPEND proc${i} "dd")


### PR DESCRIPTION
Stop using processes 54 and 61 in the tests