### PR TITLE
Update shower.cxx to avoid beam checks for AA and pA

### DIFF
--- a/test/shower.cxx
+++ b/test/shower.cxx
@@ -143,6 +143,12 @@ int main(int argc, char ** argv) {
       && type != "dd_ee" && type != "sda_ee" && type != "sdb_ee" && type != "sd_ee" && type != "el_ee"
     ) { printf("Bad argument->%s<-\n",argv[3]); return 7;}
       printf("Running in %s mode\n",argv[3]);
+      std::string beam ="pp";
+      beam[0]=type[type.size()-2];
+      beam[1]=type[type.size()-1];
+      if (beam=="AA" || beam=="pA") { 
+		  pythia.readString("Check:beams = off");
+    }      
     if (type[type.size()-1] == 'A' ) type[type.size()-1] ='p';
     if (type[type.size()-2] == 'A' ) type[type.size()-2] ='p';
     bool showerconfigured=false;


### PR DESCRIPTION
Update shower.cxx to avoid beam checks for AA and pA