### PR TITLE
Update init.f to require init for pA and AA beams

### DIFF
--- a/src/init/init.f
+++ b/src/init/init.f
@@ -35,14 +35,14 @@ ccccccc
       write(*,*)'Running the init program is not required for ee beams'
       goto 999
       end if
-      if (beam .eq. 'ion') then 
-      write(*,*)'Running the init program is not required for AA beams'
-      goto 999
-      end if
-      if (beam .eq. 'ionp') then 
-      write(*,*)'Running the init program is not required for pA beams'
-      goto 999
-      end if
+C      if (beam .eq. 'ion') then 
+C      write(*,*)'Running the init program is not required for AA beams'
+C      goto 999
+C      end if
+C      if (beam .eq. 'ionp') then 
+C      write(*,*)'Running the init program is not required for pA beams'
+C      goto 999
+C      end if
 
 cccccccccccccccccccccccccccccccccccccccccccccccccccc
 ccccccccc   Init LHAPDF


### PR DESCRIPTION
Update init.f to require init for pA and AA beams.
I assume that if qcd is active one will need to run init...