### PR TITLE
Drop APFEL dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,6 @@ include("GNUInstallDirs")
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules ${CMAKE_MODULE_PATH})
 find_package(LHAPDF REQUIRED)
 message(STATUS "SuperChic: LHAPDF_VERSION=${LHAPDF_VERSION} LHAPDF_LIBRARIES=${LHAPDF_LIBRARIES} LHAPDF_INCLUDE_DIRS=${LHAPDF_INCLUDE_DIRS}")
-find_package(APFEL REQUIRED)
-message(STATUS "SuperChic: APFEL_VERSION=${APFEL_VERSION} APFEL_LIBRARIES=${APFEL_LIBRARIES} APFEL_INCLUDE_DIRS=${APFEL_INCLUDE_DIRS}")
 #GNU
 add_compile_options("$<$<COMPILE_LANG_AND_ID:Fortran,GNU>:-std=legacy;-fbacktrace;-fcheck=all;-fno-automatic;-fimplicit-none;-ffree-line-length-none>")
 add_compile_options("$<$<COMPILE_LANG_AND_ID:Fortran,GNU>:-Wall;-Wextra;-Wno-unused-dummy-argument;-Wno-compare-reals;-Wno-do-subscript>")
@@ -190,7 +188,7 @@ endif()
 if (SUPERCHIC_ENABLE_SHARED)
   add_library(superchicLib SHARED ${sCODELHA})
   target_include_directories(superchicLib PRIVATE  ${scincludes})
-  target_link_libraries(superchicLib PRIVATE LHAPDF::LHAPDF APFEL::APFEL APFEL::APFELevol)
+  target_link_libraries(superchicLib PRIVATE LHAPDF::LHAPDF)
   target_compile_options(superchicLib PRIVATE ${sccompile_options})
   set_target_properties(superchicLib PROPERTIES 
     ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/$<0:>
@@ -204,7 +202,7 @@ endif()
 
 add_library(superchicLibstatic STATIC ${sCODELHA})
 target_include_directories(superchicLibstatic PRIVATE  ${scincludes})
-target_link_libraries(superchicLibstatic PRIVATE LHAPDF::LHAPDF APFEL::APFEL APFEL::APFELevol)
+target_link_libraries(superchicLibstatic PRIVATE LHAPDF::LHAPDF)
 target_compile_options(superchicLibstatic PRIVATE ${sccompile_options})
 set_target_properties(superchicLibstatic PROPERTIES  OUTPUT_NAME superchicLib-static
   ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/$<0:>
@@ -214,13 +212,13 @@ set_target_properties(superchicLibstatic PROPERTIES  OUTPUT_NAME superchicLib-st
   
 add_executable(superchic ${CMAKE_CURRENT_SOURCE_DIR}/src/main/superchic.f  ${InitfLHA} )
 target_include_directories(superchic PRIVATE  ${scincludes})
-target_link_libraries(superchic PRIVATE LHAPDF::LHAPDF APFEL::APFEL APFEL::APFELevol superchicLibstatic)
+target_link_libraries(superchic PRIVATE LHAPDF::LHAPDF superchicLibstatic)
 target_compile_options(superchic PRIVATE ${sccompile_options})
 set_target_properties(superchic PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/$<0:>)
 
 add_executable(init ${CMAKE_CURRENT_SOURCE_DIR}/src/init/init.f ${InitfLHA})
 target_include_directories(init PRIVATE  ${scincludes})
-target_link_libraries(init PRIVATE LHAPDF::LHAPDF APFEL::APFEL  APFEL::APFELevol )
+target_link_libraries(init PRIVATE LHAPDF::LHAPDF )
 target_compile_options(init PRIVATE ${sccompile_options})
 set_target_properties(init PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/$<0:>)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ The latest version of Superchic can be compiled with `CMake` build system.
 ### Build requirements: 
  - CMake (https://cmake.org/) > 3.16 or make
  - Fortran compiller: GNU, Intel, flang, NVFortran were tested
- - APFEL, https://apfel.hepforge.org/
  - LHAPDF, see https://lhapdf.hepforge.org/
  - Internet connection if the installation of PDFs was requested
  - C++ compiler, HepMC3 (https://ep-dep-sft.web.cern.ch/project/hepmc) and Pythia8 (https://pythia.org/) for the tests
@@ -17,8 +16,11 @@ The latest version of Superchic can be compiled with `CMake` build system.
 
 ### Runtime requirements:
 
- - APFEL, https://apfel.hepforge.org/
  - LHAPDF, see https://lhapdf.hepforge.org/
+
+## Development requirements
+
+ - APFEL, https://apfel.hepforge.org/ is needed to calculate the structure functions
 
 
 ## Obtaining the required dependencies
@@ -80,7 +82,7 @@ to run all the tests.
 
 The extra flags might be:
 - generic CMake flags, e.g. `-DCMAKE_INSTALL_PREFIX=/my/home/dir`, `-DCMAKE_Fortran_COMPILER=ifort`, `-DCMAKE_Fortran_FLAGS="-O2 -g"`, etc.
-- flags pointing to the dependencies, `-DLHAPDF_DIR=/where/the/LHAPDF/is`, `-DAPFEL_DIR=/where/the/APFEL/is`
+- flags pointing to the dependencies, `-DLHAPDF_DIR=/where/the/LHAPDF/is`
 - flags that regulate the compilation. In the current version there are the following flags: 
  - `-DSUPERCHIC_ENABLE_TESTS=ON/OFF`     Enables building of tests.
  - `-DSUPERCHIC_ENABLE_FPES=ON/OFF`      Enables floating point exceptions in the code.

--- a/makefile.make
+++ b/makefile.make
@@ -1,7 +1,5 @@
 LIBFLAGlha = -lLHAPDF
-LIBFLAGapfel = -lAPFEL -lAPFELevol
 LHAPDFLIB = `lhapdf-config --prefix`/lib
-APFELLIB = /Users/luch/Desktop/superchics/apfel_install/lib
 FC = gfortran -g -w -Wall -fbacktrace -fcheck=all -fPIC
 # -ffixed-line-length-132
 
@@ -393,7 +391,7 @@ all : init superchic superchicLib
 
 
 superchicLib: $(sCODELHA)
-	$(FC) -L$(LHAPDFLIB) -L$(APFELLIB) $(LIBFLAGlha) $(LIBFLAGapfel) -mcmodel=large -shared -fPIC -o lib/libsuperchic.so $^
+	$(FC) -L$(LHAPDFLIB) $(LIBFLAGlha) -mcmodel=large -shared -fPIC -o lib/libsuperchic.so $^
 	ar rc lib/libsuperchic.a obj/*.o
 
 superchic.o:	superchic.f
@@ -412,10 +410,10 @@ $(OBJ_PATH)%.o: %.f
 	$(FC) $(FFLAGS) -I$(INCPATH) -c  $< -o $@
 
 superchic : $(OBJ_PATH)superchic.o $(sCODELHA)
-	$(FC) $^ -L$(LHAPDFLIB) -L$(APFELLIB) $(LIBFLAGlha) $(LIBFLAGapfel) -o bin/$@
+	$(FC) $^ -L$(LHAPDFLIB) $(LIBFLAGlha) -o bin/$@
 
 init : $(OBJ_PATH)init.o $(iCODELHA)
-	$(FC) $^ -L$(LHAPDFLIB) -L$(APFELLIB) $(LIBFLAGlha) $(LIBFLAGapfel) -o bin/$@
+	$(FC) $^ -L$(LHAPDFLIB) $(LIBFLAGlha) -o bin/$@
 
 clean:
 	rm -f bin/init bin/superchic lib/lib* *.o $(OBJ_PATH)*.o

--- a/src/diss/F2ev.f
+++ b/src/diss/F2ev.f
@@ -22,15 +22,6 @@ c      f1=0d0
       return
       end
 
-      subroutine F1F2ap_old(x,q2,f2,fl)
-      implicit double precision(a-y)
-
-      f2=StructureFunctionxQ("EM","F2","total",x,dsqrt(q2))
-      fl=StructureFunctionxQ("EM","FL","total",x,dsqrt(q2))
-
-      return
-      end
-
       subroutine F1F2ap(x,q2,f2,fl)
       implicit double precision(a-y)
 


### PR DESCRIPTION
Hi @LucianHL, 

my suggestion is to drop the APFEL dependency, as it is not used and instead the structure functions are taken from "PDF".

Instead, I suggest to add the code that was used to produce the "PDF" to the repository.


