### PR TITLE
Add script for calculation of SFs and almost implement SF choice

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,7 +68,7 @@ jobs:
            yum -y install epel-release
            dnf -y install 'dnf-command(copr)'
            dnf -y copr enable averbyts/HEPrpms 
-           dnf -y install  apfel apfel-devel Rivet Rivet-devel
+           #dnf -y install  apfel apfel-devel Rivet Rivet-devel
            dnf config-manager --set-enabled powertools
            yum -y install  gcc gcc-c++ make wget which cmake cmake-data cmake-filesystem lhapdf lhapdf-devel pythia8 pythia8-devel pythia8-lhapdf HepMC3-devel HepMC-devel
     - name: Compile   
@@ -88,7 +88,7 @@ jobs:
       run: |
              dnf -y install 'dnf-command(copr)'
              dnf -y copr enable averbyts/HEPrpms 
-             dnf -y install apfel apfel-devel Rivet Rivet-devel
+             #dnf -y install apfel apfel-devel Rivet Rivet-devel
              dnf -y install  gcc gcc-c++ gcc-gfortran make wget which cmake cmake-data cmake-filesystem lhapdf lhapdf-devel pythia8 pythia8-devel pythia8-lhapdf HepMC3-devel HepMC-devel 
              tee > /tmp/oneAPI.repo << EOF
              [oneAPI]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -121,7 +121,8 @@ jobs:
       run: |
           brew install wget coreutils gcc gsed make
           brew tap davidchall/hep
-          brew install lhapdf apfel pythia8 hepmc3 hepmc2 rivet yoda
+          brew install lhapdf pythia8 hepmc3 hepmc2 
+#          brew install  apfel rivet yoda
     - name: Compile_with_make
       run: |
            mkdir -p obj lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ option(SUPERCHIC_ENABLE_FPES         "Enables FPEs." OFF)
 option(SUPERCHIC_ENABLE_DOCS         "Enables compilation of manual." OFF)
 option(SUPERCHIC_ENABLE_SHARED       "Enables compilation of shared library." OFF)
 option(SUPERCHIC_INSTALL_LIBRARIES   "Enables installation of libraries." OFF)
-option(SUPERCHIC_ENABLE_APFELSF      "Enables compilation of executables used to created SF with APFEL." ON)
+option(SUPERCHIC_ENABLE_APFELSF      "Enables compilation of executables used to created SF with APFEL." OFF)
 
 include("GNUInstallDirs")
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules ${CMAKE_MODULE_PATH})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ option(SUPERCHIC_ENABLE_FPES         "Enables FPEs." OFF)
 option(SUPERCHIC_ENABLE_DOCS         "Enables compilation of manual." OFF)
 option(SUPERCHIC_ENABLE_SHARED       "Enables compilation of shared library." OFF)
 option(SUPERCHIC_INSTALL_LIBRARIES   "Enables installation of libraries." OFF)
+option(SUPERCHIC_ENABLE_APFELSF      "Enables compilation of executables used to created SF with APFEL." ON)
 
 include("GNUInstallDirs")
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules ${CMAKE_MODULE_PATH})
@@ -286,6 +287,12 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/share/SuperChic/SplinesWithVariableKno
               ${CMAKE_CURRENT_SOURCE_DIR}/share/SuperChic/Lepretre_25_103.dat 
               DESTINATION ${CMAKE_INSTALL_DATADIR}/SuperChic COMPONENT data)
 INSTALL(DIRECTORY ${CMAKE_BINARY_DIR}/unpacked/SF  DESTINATION ${CMAKE_INSTALL_DATADIR}/SuperChic)
+
+if (SUPERCHIC_ENABLE_APFELSF)
+  find_package(APFEL REQUIRED)
+  add_executable(apfelsf SF/apfelsf.f)
+  target_link_libraries(apfelsf PRIVATE APFEL::APFEL APFEL::APFELevol)
+endif()
 if (SUPERCHIC_ENABLE_TESTS)
   ENABLE_TESTING()
   add_subdirectory(test)

--- a/README.md
+++ b/README.md
@@ -130,3 +130,15 @@ For the debug purposes it is useful to compile SeuperChic with the following opt
 -DSUPERCHIC_ENABLE_FPES=ON -DSUPERCHIC_ENABLE_TESTS=ON -DSUPERCHIC_ENABLE_ALL_TESTS=ON -DSUPERCHIC_DOWNLOAD_PDFS=ON -DCMAKE_Fortran_FLAGS="-O2 -g"
 ```
 
+## Developing  SuperChic
+The CMake build system has a developer-only option `SUPERCHIC_ENABLE_APFELSF`. With this option turned on,
+an executable `apfelsf` can be build (APFEL and LHAPDF are required). The executable can be used to rebuild the SF "pseudo-PDFs',e.g.
+```
+cmake -S . -B BUILD -DSUPERCHIC_ENABLE_APFELSF=ON
+cmake --build BUILD
+BUILD/apfelsf <PDFNAME>
+
+```
+The results will be stored in the directory SF_<PDFNAME>. <PDFNAME> should be installed and accessible by LHAPDF.
+
+

--- a/SF/apfelsf.f
+++ b/SF/apfelsf.f
@@ -1,0 +1,38 @@
+      program apfelsf
+      implicit none
+      double precision alphas,alphasPDF
+      integer order, argc, N
+      character pdfname*100
+      argc=iargc()
+      if (argc.LT.1) THEN
+        write(*,*)'Not enought arguments',argc
+        stop 1
+      end if
+      CALL GETARG(1, pdfname)
+      call SetMassScheme("ZM-VFNS")
+      call SetMaxFlavourPDFs(5)    
+      call SetQLimits(1d0,1d5)
+      call SetNumberOfGrids(3)
+      call SetGridParameters(1,100,3,1d-9)
+      call SetGridParameters(2,100,3,1d-4)
+      call SetGridParameters(3,100,3,1d-2)
+
+      call InitPDFsetByName(trim(pdfname)) !AV
+      call InitPDF(0) !AV
+      call numberPDF(N)
+      call GetOrderAs(order)
+      call SetPerturbativeOrder(order) 
+
+      
+      call SetPDFSet(trim(pdfname))
+      alphas=alphasPDF(91.1876d0)
+      call SetAlphaQCDRef(alphas,91.1876d0) 
+
+      call SetReplica(0)
+      
+      call InitializeAPFEL_DIS
+      call CacheStructureFunctionsAPFEL(1d0)
+       
+      call EXECUTE_COMMAND_LINE('mkdir -p SF_'//trim(pdfname)) ! AV
+      call LHAPDFgridStructureFunctions(N,1d0,'SF_'//trim(pdfname))
+      end

--- a/src/diss/apfelinit.f
+++ b/src/diss/apfelinit.f
@@ -5,10 +5,14 @@
 
       include 'pdfinf.f'
       include 'ewsf.f'
-
-c      call initpdfsetm(2,'SF_MMHT2015qed_nnlo')
-      call initpdfsetm(2,'SF_MSHT20qed_nnlo')
-      call initpdfm(2,0)
+      
+      if (SFPDFname .eq. 'SF_MSHT20qed_nnlo') goto 1
+!      if (SFPDFname .eq. 'SF_MMHT2015qed_nnlo') goto 1
+      write(*,*)'Wrong SF table name: '//SFPDFname
+      stop 1
+  1   continue
+      call initpdfsetm(2,SFPDFname)
+      call initpdfm(2,SFPDFmember)
 
       Sin2ThetaW=0.23126d0
       ve = - 0.5d0 + 2d0 * Sin2ThetaW

--- a/src/inc/pdfinf.f
+++ b/src/inc/pdfinf.f
@@ -1,8 +1,12 @@
       character*100 PDFname
+      character*100 SFPDFname
       integer PDFmember
+      integer SFPDFmember
       double precision pdfq2min
       integer pdfwarn
       common/pdfint/PDFname
+      common/sfpdfint/SFPDFname
       common/pdfint1/PDFmember
+      common/sfpdfint1/SFPDFmember
       common/pdfbounds/pdfq2min
       common/pdfwarn/pdfwarn

--- a/src/init/init.f
+++ b/src/init/init.f
@@ -28,6 +28,8 @@ ccccccc
       read(*,*)dum
       read(*,*)PDFname
       read(*,*)PDFmember
+      SFPDFname='SF_MSHT20qed_nnlo'
+      SFPDFmember=0
       read(*,*)dum
       read(*,*)proc
       read(*,*)beam

--- a/src/main/superchic.f
+++ b/src/main/superchic.f
@@ -135,6 +135,8 @@ ccccccc
       read(*,*)dum
       read(*,*)PDFname
       read(*,*)PDFmember
+      SFPDFname='SF_MSHT20qed_nnlo'
+      SFPDFmember=0
       read(*,*)dum
       read(*,*)proc
       read(*,*)beam


### PR DESCRIPTION
In this MR:
 - Code that should produce "SF" PDFs using APFEL
 - Some modifications into the SC code to allow arbitrary SF PDFs from the allowed list. So far the input name/members are hardcoded.
 - Also do not install Rivet  -- it is too expensive, esp on  MacOS.
 