### PR TITLE
Add missing beams for pythia8.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+Version 5.2
+ - Beams are propagated to LHE for elastic processes.
 Version 5.0
  - New build system 'CMake'
  - Numerous tests with 'CMake'

--- a/src/unw/unwprint.f
+++ b/src/unw/unwprint.f
@@ -165,7 +165,21 @@ ccccccccccccccccccccccccccccccccccccccccccccccc
             aqcdup=alphas(mx**2)
             write(45,*)'<event>'
             strt=3
-            write(45,304)nup,idprup,xwgtup,scalup,aqedup,aqcdup
+            if(diff.eq.'el'.and. idup(1).eq. idup(3))then            
+            strt=1
+              if(i.eq.1) then           
+              do m=3,5
+                mothup(1,m)=1
+                mothup(2,m)=2
+              enddo
+              do m=6,nup+2
+                if (mothup(1,m).ne.0) mothup(1,m)=mothup(1,m)+2
+                if (mothup(2,m).ne.0) mothup(2,m)=mothup(2,m)+2
+              enddo
+              endif
+            endif
+
+            write(45,304)nup+3-strt,idprup,xwgtup,scalup,aqedup,aqcdup         
             if(beam.eq.'prot'.or.beam.eq.'el')then
                do m=strt,nup+2
                   write(45,303)idup(m),istup(m),mothup(1,m),

--- a/src/unw/unwprint_q.f
+++ b/src/unw/unwprint_q.f
@@ -357,7 +357,20 @@ ccccccccccccccccccccccccccccccccccccccccccccccc
                
             write(45,*)'<event>'
             strt=3
-            write(45,304)nup-1,idprup,xwgtup,scalup,aqedup,aqcdup
+            if(diff.eq.'el' .and. idup(1).eq. idup(3) )then
+                 strt=1
+                 if(i.eq.1) then
+                 do m=3,5
+                   mothup(1,m)=1
+                   mothup(2,m)=2
+                 enddo
+                 do m=6,nup+1
+                   if (mothup(1,m).ne.0) mothup(1,m)=mothup(1,m)+2
+                   if (mothup(2,m).ne.0) mothup(2,m)=mothup(2,m)+2
+                 enddo
+                 endif
+            endif
+            write(45,304)nup+2-strt,idprup,xwgtup,scalup,aqedup,aqcdup
             if(beam.eq.'prot'.or.beam.eq.'el')then
                if(diff.eq.'sd')then
                   if(pup(3,3).lt.0d0)then
@@ -393,7 +406,8 @@ ccccccccccccccccccccccccccccccccccccccccccccccc
      &                 ,spinup(m)
                   enddo
                endif
-               else
+               endif
+               if(diff.eq.'dd')then
                   do m=3,nup+1
                      write(45,303)idup(m),istup(m),mothup(1,m),
      &                    mothup(2,m),icolup(1,m),icolup(2,m),pup(1,m)
@@ -401,13 +415,19 @@ ccccccccccccccccccccccccccccccccccccccccccccccc
      &                 ,spinup(m)
                   enddo
                endif
+
+               if(diff.eq.'el')then
+                 do m=strt,nup+1
+                     write(45,303)idup(m),istup(m),mothup(1,m),
+     &                    mothup(2,m),icolup(1,m),icolup(2,m),pup(1,m)
+     &                    ,pup(2,m),pup(3,m),pup(4,m),pup(5,m),vtimup(m)
+     &                 ,spinup(m)
+                 enddo
+               endif
+
+
+
             elseif(beam.eq.'ion'.or.beam.eq.'ionp')then
-c$$$               do m=strt,nup+2
-c$$$                  write(45,203)idup(m),istup(m),mothup(1,m),
-c$$$     &                 mothup(2,m),icolup(1,m),icolup(2,m),pup(1,m)
-c$$$     &                 ,pup(2,m),pup(3,m),pup(4,m),pup(5,m),vtimup(m)
-c$$$     &                 ,spinup(m)
-c$$$               enddo
                do m=3,nup+1
                   write(45,203)idup(m),istup(m),mothup(1,m),
      &                 mothup(2,m),icolup(1,m),icolup(2,m),pup(1,m)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,12 +27,10 @@ target_link_libraries(validator PRIVATE HepMC3::HepMC3)
 target_compile_features(validator PRIVATE cxx_std_11)
 
 
-find_package(HepMC2)
 find_package(Pythia8 8.3 REQUIRED)
 add_executable(shower ${CMAKE_CURRENT_SOURCE_DIR}/shower.cxx)
-target_link_libraries(shower PRIVATE HepMC2::HepMC2 Pythia8::Pythia8 )
+target_link_libraries(shower PRIVATE HepMC3::HepMC3 Pythia8::Pythia8 )
 target_compile_features(shower PRIVATE cxx_std_11)
-target_compile_definitions(shower PRIVATE -DHEPMC2=1)
 message(STATUS "SuperChic test: PYTHIA8_VERSION=${PYTHIA8_VERSION} PYTHIA8_LIBRARIES=${PYTHIA8_LIBRARIES} PYTHIA8_INCLUDE_DIRS=${PYTHIA8_INCLUDE_DIRS}")
 
 
@@ -99,10 +97,10 @@ endmacro()
 macro(sctestlhe NN MM df pr)
 if (SUPERCHIC_ENABLE_PROFILE)
   add_test(NAME SUPERCHIC_${NN}_${MM} COMMAND sh -c "valgrind --tool=callgrind  --callgrind-out-file=CALLGRIND_SUPERCHIC_${NN}_${MM}.log ${PROJECT_BINARY_DIR}/bin/superchic < ${CMAKE_CURRENT_BINARY_DIR}/input.DAT_${MM}" WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/RUN_${NN})
-  set_tests_properties( SUPERCHIC_${NN}_${MM} PROPERTIES TIMEOUT 1500 ENVIRONMENT "${STANDARDENVIRONMENT}" DEPENDS INIT_${NN})
+  set_tests_properties( SUPERCHIC_${NN}_${MM} PROPERTIES TIMEOUT 2500 ENVIRONMENT "${STANDARDENVIRONMENT}" DEPENDS INIT_${NN})
 else()
   add_test(NAME SUPERCHIC_${NN}_${MM} COMMAND sh -c "${PROJECT_BINARY_DIR}/bin/superchic < ${CMAKE_CURRENT_BINARY_DIR}/input.DAT_${MM}" WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/RUN_${NN})
-  set_tests_properties( SUPERCHIC_${NN}_${MM} PROPERTIES TIMEOUT 1000 ENVIRONMENT "${STANDARDENVIRONMENT}" DEPENDS INIT_${NN})
+  set_tests_properties( SUPERCHIC_${NN}_${MM} PROPERTIES TIMEOUT 2000 ENVIRONMENT "${STANDARDENVIRONMENT}" DEPENDS INIT_${NN})
 endif()  
 
   add_test(NAME SHOWER_${NN}_${MM} COMMAND shower ${CMAKE_CURRENT_BINARY_DIR}/RUN_${NN}/evrecs/evrectest${MM}.dat ${CMAKE_CURRENT_BINARY_DIR}/RUN_${NN}/evrecs/showered${MM}.hepmc ${df} ${pr} real)

--- a/test/shower.cxx
+++ b/test/shower.cxx
@@ -12,11 +12,7 @@
 // It uses the ttsample.lhe(.gz) input file, the latter only with 100 events.
 
 // Modified for Superchic
-#ifndef HEPMC2
 #include "Pythia8Plugins/HepMC3.h"
-#else
-#include "Pythia8Plugins/HepMC2.h"
-#endif
 #include "Pythia8/Pythia.h"
 using namespace Pythia8;
 


### PR DESCRIPTION
- Add missing beams for pythia8:
     - For the elastic processes the initial beams are written to LHE file in case the beams are intact, i.e. first two particles are the same as the beam.
     - See also https://gitlab.com/Pythia8/releases/-/issues/453

- Use only HepMC3 for Showering. It should work fine with the changes above.
- Increase the timeouts for generation.
- Drop some commented code