### PR TITLE
Update superchic.tex

### DIFF
--- a/doc/superchic.tex
+++ b/doc/superchic.tex
@@ -696,9 +696,9 @@ and \texttt{p(d)}, respectively.
 \subsection{Process 55: $W^+W^-$ production ($pp$)}
 
 Two--photon induced $W$ boson pair production. Both muon and electron decay channels are implemented, and set according to \texttt{wlp}, 
-\texttt{wlm} in the input card, with ${\rm Br}(W\to \nu \mu)=10.63\%$ and ${\rm Br}(W\to \nu e)=10.71\%$. Spin correlations may be  included with 
-the \texttt{spincorr} flag. Cuts on the final--state muons may be placed using the input file, with the momenta $\mu^+(9)$, $\mu^-(11)$, as 
-defined in Table~\ref{table:proc}, given by \texttt{p(a)}, \texttt{p(b)},  and similarly for the election decay channel.
+\texttt{wlm} in the input card, with ${\rm Br}(W\to \nu \mu)=10.63\%$ and ${\rm Br}(W\to \nu e)=10.71\%$. Spin correlations may be included with 
+the \texttt{spincorr} flag. Cuts on the final--state leptons may be placed using the input file, with the momenta $l^+(9)$, $l^-(11)$, as 
+defined in Table~\ref{table:proc}, given by \texttt{p(a)}, \texttt{p(b)}, respectively (under the 2 body final state).
 
 \subsection{Processes 56--58: $l^+l^-$ production ($pp$)}
 


### PR DESCRIPTION
This commit generalizes text in photon-induced WW case for muons and electrons and specifies which parameters should be changed (otherwise, one can use a 4-body final state decay to set to cuts).

PS: The `@PROJECT_VERSION@` in the file gives latex compilation errors for me, having an instruction how to compile the tex can be also useful 